### PR TITLE
Combine both grunt commands into the same exec

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -27,6 +27,6 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "postinstall" : "grunt init; grunt build"
+    "postinstall" : "grunt init build"
   }
 }


### PR DESCRIPTION
The `;` was causing some issues when running `yo` on Windows. Turns out you can combine `grunt init ; grunt build` into `grunt init build`.
